### PR TITLE
The module didn't worked for non-GMs.

### DIFF
--- a/scripts/custom-journal.js
+++ b/scripts/custom-journal.js
@@ -20,7 +20,7 @@ class CustomJournalSheet extends JournalSheet {
 		let buttons = super._getHeaderButtons();
 
 		// Token Configuration
-		const canConfigure = game.user.isGM || (this.actor.owner && game.user.can("TOKEN_CONFIGURE"));
+		const canConfigure = game.user.isGM || this.entity.owner;
 		if (this.options.editable && canConfigure) {
 			buttons = [
 				{


### PR DESCRIPTION
`this.actor.owner` didn't work and caused the module to crash. No player could see nor open any journals once the module was implemented.